### PR TITLE
Upgrade to getos@2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "colors-tmpl": "~0.1.0",
     "core-util-is": "~1.0.1",
     "cpr": "~0.3.2",
-    "getos": "~1.0.1",
+    "getos": "^2.3.0",
     "js-yaml": "~3.0.2",
     "map-async": "~0.1.1",
     "mkdirp": "~0.5.0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -11,11 +11,11 @@ const tmpl    = path.join(__dirname, 'exercises/am_i_ready/problem.md.tmpl')
     , problem = fs.readFileSync(tmpl, 'utf-8')
 
 
-getos(function (err, distro) {
+getos(function (err, os) {
   if (err)
     throw err
 
-  var markdown = varstring(problem, instructions[distro] || instructions.Other)
+  var markdown = varstring(problem, instructions[os.dist] || instructions.Other)
 
   fs.writeFileSync(out, markdown, 'utf8')
 })


### PR DESCRIPTION
Fixes #50.

The old [`getos`](http://npm.im/getos) silently returns with no callback called on unknown distributions.